### PR TITLE
Handle newer ffmpeg version which generates an already relative m3u8

### DIFF
--- a/src/main/java/org/opencastproject/distribution/hls/FFmpegHLSEncoderEngine.java
+++ b/src/main/java/org/opencastproject/distribution/hls/FFmpegHLSEncoderEngine.java
@@ -1,5 +1,5 @@
 /*
- * This file has been modified from the original distribution. 
+ * This file has been modified from the original distribution.
  * Modifications Copyright 2013 The Trustees of Indiana University and Northwestern University.
  */
 
@@ -25,6 +25,8 @@ import org.opencastproject.composer.api.EncoderException;
 import org.opencastproject.composer.api.EncodingProfile;
 import org.opencastproject.composer.impl.ffmpeg.FFmpegEncoderEngine;
 import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -40,13 +42,16 @@ import java.util.List;
  */
 public class FFmpegHLSEncoderEngine extends FFmpegEncoderEngine {
 
+  /** Logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(FFmpegHLSEncoderEngine.class);
+
   /**
    * Creates the ffmpeg encoder engine.
    */
   public FFmpegHLSEncoderEngine() {
     super();
   }
- 
+
   public void activate(ComponentContext cc) {
     super.activate(cc);
   }
@@ -81,6 +86,15 @@ public class FFmpegHLSEncoderEngine extends FFmpegEncoderEngine {
               if (line.startsWith(m3u8.getParentFile().getPath())) {
                   File oldFile = new File(line);
                   File newFile = new File(destination.getParentFile(), oldFile.getName().replace(oldName, newName));
+                  logger.debug("Renaming " + oldFile + " to " + newFile);
+                  if (!oldFile.renameTo(newFile)) {
+                      throw new EncoderException("Could not rename segment file!");
+                  }
+                  pw.println(newFile.getName());
+              } else if (line.endsWith(".ts")) {
+                  File oldFile = new File(m3u8.getParentFile(), line);
+                  File newFile = new File(destination.getParentFile(), oldFile.getName().replace(oldName, newName));
+                  logger.debug("Renaming " + oldFile + " to " + newFile);
                   if (!oldFile.renameTo(newFile)) {
                       throw new EncoderException("Could not rename segment file!");
                   }
@@ -120,4 +134,3 @@ public class FFmpegHLSEncoderEngine extends FFmpegEncoderEngine {
     return outputFile;
   }
 }
-

--- a/src/test/java/org/opencastproject/distribution/hls/HLSDistributionServiceImplTest.java
+++ b/src/test/java/org/opencastproject/distribution/hls/HLSDistributionServiceImplTest.java
@@ -193,7 +193,7 @@ public class HLSDistributionServiceImplTest {
 
   @Test
   public void testAudioDistribution() throws Exception {
-    
+
     // Distribute only some of the elements in the mediapackage
     Job job1 = service.distribute(mp, "track-aac"); // "track-aac" should be distributed
     JobBarrier jobBarrier = new JobBarrier(serviceRegistry, 500, job1);
@@ -255,7 +255,7 @@ public class HLSDistributionServiceImplTest {
         final String parentPath = file.getParentFile().getPath();
         String line = null;
         while ((line = reader.readLine()) != null) {
-            Assert.assertEquals("Playlist file \"" + file + "\" has must have relative paths! (has \"" + line + "\")", false, line.startsWith(parentPath));
+            Assert.assertEquals("Playlist file \"" + file + "\" must have relative paths! (has \"" + line + "\")", false, line.startsWith(parentPath));
         }
     }
 
@@ -282,7 +282,7 @@ public class HLSDistributionServiceImplTest {
     Job job2 = service.retract(mp, element.getIdentifier());
     jobBarrier = new JobBarrier(serviceRegistry, 500, job2);
     jobBarrier.waitForJobs();
-    
+
     System.out.println("Element ref: " + element.getReference());
     System.out.println("DistributedDir: " + service.getDistributedFile(mp, element).getAbsolutePath());
 
@@ -292,7 +292,7 @@ public class HLSDistributionServiceImplTest {
     Assert.assertEquals(elementCount, mp.getElements().length);
     Assert.assertNotNull(mp.getElementById("track-h264"));
     System.out.println("ElementDir: " + service.getDistributionFile(mp, mp.getElementById("track-h264")).getAbsolutePath());
-    
+
     Assert.assertFalse(service.getDistributionFile(mp, mp.getElementById("track-h264")).isFile());
     Assert.assertFalse(new File(mediaDir, "media.mov.m3u8").exists()); // HLS playlist should have been retracted
     Assert.assertFalse(new File(mediaDir, "media.mov-000.ts").exists()); // HLS segment files should have been retracted


### PR DESCRIPTION
The version of ffmpeg bundled with the Avalon 4.0.1 OVA generates m3u8s that are already relative and thus the logic in this distribution module was missing moving these files to their distribution location.
